### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/snowflake-devops.yml
+++ b/.github/workflows/snowflake-devops.yml
@@ -11,6 +11,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Set minimal permissions for the workflow
+permissions:
+  contents: read
+
 jobs:
   deploy-snowflake-changes-job:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/83Maverick/Schema_Change_CICD/security/code-scanning/1](https://github.com/83Maverick/Schema_Change_CICD/security/code-scanning/1)

To fix the issue, we will add an explicit `permissions` block to the workflow file. This block will be added at the workflow root level to apply to all jobs unless overridden at the job level. Since the workflow primarily involves checking out the repository and running schemachange, the minimal necessary permissions are `contents: read`. If the workflow requires additional permissions in the future, they can be added explicitly.

The changes will be made to the `.github/workflows/snowflake-devops.yml` file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
